### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Yarn-based Turborepo monorepo for "anyclick" — a React developer toolkit that enables right-click feedback capture with DOM context. It consists of 13 npm packages under `@ewjdev/` scope plus a Next.js 16 documentation/demo site (`apps/web`).
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `yarn install` |
+| Build all packages | `yarn build` |
+| Dev mode (all) | `yarn dev` |
+| Format check | `yarn format:check` |
+| Format fix | `yarn format` |
+| Typecheck packages | `yarn turbo run typecheck --filter=./packages/*` |
+| Build web app | `yarn turbo run build --filter=web-app` |
+
+### Running the dev server
+
+- `yarn dev` starts Turborepo dev mode for all packages (tsup watchers) and the web app (Next.js with Turbopack + HTTPS).
+- The web app will be available at **https://localhost:3000** with a self-signed certificate (auto-generated via mkcert on first run).
+- No external services are required for basic development. GitHub, Jira, OpenAI, and Upstash integrations are optional and controlled by env vars in `.env.local`.
+
+### Important caveats
+
+- **Node.js 22+** is required (CI uses Node 22; `engines` field says `>=20.9.0` but CONTRIBUTING.md specifies 22+).
+- **`yarn build` must complete before `yarn dev`** on a fresh clone since packages depend on each other's build outputs (`^build` in turbo.json).
+- The web app's `"lint": "next lint"` script has a known issue with Next.js 16 CLI (the command fails with "Invalid project directory provided"). CI only lints packages, not the web app: `yarn turbo run lint --filter=./packages/*`.
+- **Format check** (`yarn format:check`) will report ~91 pre-existing formatting issues. These are in `.cursor/plans/`, docs, and some source files. This is the repo's current state.
+- The `--experimental-https` flag on the web dev server auto-generates SSL certs in `apps/web/certificates/` on first run — no manual step required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future agents working in this repository.

## What's included

- Quick reference table for common development commands
- Instructions for running the dev server
- Important caveats discovered during setup:
  - Node.js 22+ requirement
  - `yarn build` must run before `yarn dev` on fresh clones
  - Known `next lint` CLI issue with Next.js 16
  - Pre-existing formatting issues in the repo
  - HTTPS auto-cert generation behavior

## Update Script

The VM startup update script runs:
```
yarn install --frozen-lockfile
yarn build
```

## Demo

[anyclick_dev_environment_walkthrough.mp4](https://cursor.com/agents/bc-6478ee11-1330-4a85-bbb1-c7123f38fc97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanyclick_dev_environment_walkthrough.mp4)

The application running in dev mode at https://localhost:3000.

[Anyclick homepage loaded](https://cursor.com/agents/bc-6478ee11-1330-4a85-bbb1-c7123f38fc97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Examples page](https://cursor.com/agents/bc-6478ee11-1330-4a85-bbb1-c7123f38fc97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexamples_page.webp)
[Basic setup example page](https://cursor.com/agents/bc-6478ee11-1330-4a85-bbb1-c7123f38fc97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbasic_setup_example.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6478ee11-1330-4a85-bbb1-c7123f38fc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6478ee11-1330-4a85-bbb1-c7123f38fc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

